### PR TITLE
Addressed issues with the et_setup script

### DIFF
--- a/et_setup.sh
+++ b/et_setup.sh
@@ -131,11 +131,12 @@ alias joern='java -jar $JOERN/bin/joern.jar'
 mkvirtualenv joern
 wget https://github.com/nigelsmall/py2neo/archive/py2neo-2.0.7.tar.gz
 tar zxvf py2neo*
-cd py2neo
-python setup.py install
+cd py2neo-py2neo-2.0.7
+sudo python setup.py install
 
 # Install Rust
-curl https://sh.rustup.rs -sSf | sh
+curl -f -L https://static.rust-lang.org/rustup.sh -O
+sudo sh rustup.sh
 cargo install ripgrep
 
 # Personal config


### PR DESCRIPTION
I encountered a few problems while running `vagrant up`:
- The extracted py2neo directory name doesn't match the one in the cd command (existing, related issue: https://github.com/ctfhacker/EpicTreasure/issues/17)
- Admin privileges were needed to run the py2neo installation script
- The currently used rustup shell script is interactive, which causes vagrant to throw an error

The given changes resolved the issues.